### PR TITLE
feat RA config & env var parsing 

### DIFF
--- a/src/RustAnalyzer/Infrastructure/Options.cs
+++ b/src/RustAnalyzer/Infrastructure/Options.cs
@@ -1,6 +1,10 @@
 using System.ComponentModel;
+using System.Drawing.Design;
+using System.IO;
 using System.Runtime.InteropServices;
 using Community.VisualStudio.Toolkit;
+using Microsoft.VisualStudio.Shell;
+using Newtonsoft.Json.Linq;
 
 namespace KS.RustAnalyzer.Infrastructure;
 
@@ -27,6 +31,12 @@ public interface ISettingsServiceDefaults
     public string AdditionalTestExecutionArguments { get; set; }
 
     public string TestExecutionEnvironment { get; set; }
+
+    public string LspInitializationOptions { get; set; }
+
+    public string RustAnalyzerEnvArguments { get; set; }
+
+    public bool EnableRustAnalyzerStderrLogging { get; set; }
 }
 
 public class Options : BaseOptionModel<Options>, ISettingsServiceDefaults
@@ -84,4 +94,127 @@ public class Options : BaseOptionModel<Options>, ISettingsServiceDefaults
     [DisplayName("Execution environment")]
     [Description($"Additioanal environment variables to set for test execution. Default: RUST_BACKTRACE=full. Example: RUST_BACKTRACE=1.")]
     public string TestExecutionEnvironment { get; set; } = "RUST_BACKTRACE=full";
+
+    [Browsable(true)]
+    [Category(SettingsInfo.KindConfig)]
+    [DisplayName("Rust analyzer lsp initialization initializationOptions")]
+    [Description("JSON object parsed to initializationOptions, see https://rust-analyzer.github.io/book/configuration\n" +
+        "you can overwrite this global setting by placing a file named 'lsp_initializationOptions.json' in your top level project directory" +
+        "the two files will then get merged using a deep merge strategy (see https://jsoncompare.com/json-merge-tool)\n" +
+        "!!Make shure the json you enter is escaped correctly (no\\ in Windows paths or sth)\n" +
+        "Restarting VS is required for changes to this settign (or the .json) to take effect")]
+    [Editor(typeof(System.ComponentModel.Design.MultilineStringEditor), typeof(UITypeEditor))]
+    public string LspInitializationOptions { get; set; } = "{}";
+
+    public JObject GetMergedLspInitializationOptions(string projectRootDir)
+    {
+        var configString = LspInitializationOptions;
+        var lspInitOpsPath = !string.IsNullOrEmpty(projectRootDir) ? Path.Combine(projectRootDir, "lsp_initializationOptions.json") : null;
+        var globalInitOps = new JObject();
+        var localInitOps = new JObject();
+
+        if (!string.IsNullOrWhiteSpace(configString))
+        {
+            try
+            {
+                globalInitOps = JObject.Parse(configString);
+            }
+            catch (System.Exception ex)
+            {
+                RustAnalyzerPackage.JTF.RunAsync(async () => 
+                {
+                    await VsCommon.ShowErrorMessageAsync(
+                        "Rust Analyzer",
+                        $"Error parsing LSP initialization options from settings: {ex.Message}\n\nPlease check your LSP initialization options in Tools > Options > Rust Analyzer > General.");
+                }).FireAndForget();
+                globalInitOps = new JObject();
+            }
+        }
+
+        if (!string.IsNullOrEmpty(lspInitOpsPath) && File.Exists(lspInitOpsPath))
+        {
+            try
+            {
+                string overrideString = File.ReadAllText(lspInitOpsPath);
+                if (!string.IsNullOrWhiteSpace(overrideString))
+                {
+                    localInitOps = JObject.Parse(overrideString);
+                }
+            }
+            catch (IOException ex)
+            {
+                RustAnalyzerPackage.JTF.RunAsync(async () => 
+                {
+                    await VsCommon.ShowErrorMessageAsync(
+                        "Rust Analyzer",
+                        $"Error reading JSON file from '{lspInitOpsPath}': {ex.Message}");
+                }).FireAndForget();
+                localInitOps = new JObject();
+            }
+            catch (System.Exception ex)
+            {
+                RustAnalyzerPackage.JTF.RunAsync(async () => 
+                {
+                    await VsCommon.ShowErrorMessageAsync(
+                        "Rust Analyzer",
+                        $"Error parsing JSON from file '{lspInitOpsPath}': {ex.Message}");
+                }).FireAndForget();
+                localInitOps = new JObject();
+            }
+        }
+
+        try
+        {
+            globalInitOps.Merge(localInitOps, new JsonMergeSettings
+            {
+                MergeArrayHandling = MergeArrayHandling.Replace,
+                MergeNullValueHandling = MergeNullValueHandling.Merge
+            });
+        }
+        catch (System.Exception ex)
+        {
+            RustAnalyzerPackage.JTF.RunAsync(async () => 
+            {
+                await VsCommon.ShowErrorMessageAsync(
+                    "Rust Analyzer", 
+                    $"Error merging LSP initialization options: {ex.Message}");
+            }).FireAndForget();
+            return new JObject();
+        }
+
+        return globalInitOps;
+    }
+
+    [Browsable(true)]
+    [Category(SettingsInfo.KindConfig)]
+    [DisplayName("Rust analyzer environment variables")]
+    [Description("Environment variables passed to rust-analyzer.exe, example:\nRA_LOG=info Env2=Test Env3=Hello")]
+    public string RustAnalyzerEnvArguments { get; set; } = string.Empty;
+
+    public JObject GetRustAnalyzerEnvArguments()
+    {
+        var envArgs = new JObject();
+        foreach (var arg in RustAnalyzerEnvArguments.Split(new[] { ' ' }, System.StringSplitOptions.RemoveEmptyEntries))
+        {
+            var kvp = arg.Split(new[] { '=' }, 2);
+
+            // Set Env inputs without = to empty string
+            var val = string.Empty;
+            if (kvp.Length == 2)
+            {
+                val = kvp[1];
+            }
+
+            envArgs[kvp[0]] = val;
+        }
+
+        return envArgs;
+    }
+
+    [Browsable(true)]
+    [Category(SettingsInfo.KindConfig)]
+    [DisplayName("Enable Rust Analyzer Stderr Logging")]
+    [Description("If enabled, output from rust-analyzer will be logged to the Output window.")]
+    public bool EnableRustAnalyzerStderrLogging { get; set; } = false;
+
 }

--- a/src/RustAnalyzer/Infrastructure/Options.cs
+++ b/src/RustAnalyzer/Infrastructure/Options.cs
@@ -92,17 +92,17 @@ public class Options : BaseOptionModel<Options>, ISettingsServiceDefaults
     [Browsable(true)]
     [Category(SettingsInfo.KindTest)]
     [DisplayName("Execution environment")]
-    [Description($"Additioanal environment variables to set for test execution. Default: RUST_BACKTRACE=full. Example: RUST_BACKTRACE=1.")]
+    [Description($"Additional environment variables to set for test execution. Default: RUST_BACKTRACE=full. Example: RUST_BACKTRACE=1.")]
     public string TestExecutionEnvironment { get; set; } = "RUST_BACKTRACE=full";
 
     [Browsable(true)]
     [Category(SettingsInfo.KindConfig)]
-    [DisplayName("Rust analyzer lsp initialization initializationOptions")]
-    [Description("JSON object parsed to initializationOptions, see https://rust-analyzer.github.io/book/configuration\n" +
-        "you can overwrite this global setting by placing a file named 'lsp_initializationOptions.json' in your top level project directory" +
-        "the two files will then get merged using a deep merge strategy (see https://jsoncompare.com/json-merge-tool)\n" +
-        "!!Make shure the json you enter is escaped correctly (no\\ in Windows paths or sth)\n" +
-        "Restarting VS is required for changes to this settign (or the .json) to take effect")]
+    [DisplayName("LSP Initialization Options")]
+    [Description("JSON object for LSP initializationOptions, see https://rust-analyzer.github.io/book/configuration.\n" +
+        "You can override this global setting by placing a file named 'lsp_initializationOptions.json' in your top-level project directory. " +
+        "The two JSON objects will be deep-merged.\n" +
+        "Make sure the JSON is valid and strings are correctly escaped (e.g., use '\\\\' or just '/' for paths in Windows).\n" +
+        "Reopening the Solution is required for changes to this setting to take effect.")]
     [Editor(typeof(System.ComponentModel.Design.MultilineStringEditor), typeof(UITypeEditor))]
     public string LspInitializationOptions { get; set; } = "{}";
 
@@ -121,7 +121,7 @@ public class Options : BaseOptionModel<Options>, ISettingsServiceDefaults
             }
             catch (System.Exception ex)
             {
-                RustAnalyzerPackage.JTF.RunAsync(async () => 
+                RustAnalyzerPackage.JTF.RunAsync(async () =>
                 {
                     await VsCommon.ShowErrorMessageAsync(
                         "Rust Analyzer",
@@ -143,7 +143,7 @@ public class Options : BaseOptionModel<Options>, ISettingsServiceDefaults
             }
             catch (IOException ex)
             {
-                RustAnalyzerPackage.JTF.RunAsync(async () => 
+                RustAnalyzerPackage.JTF.RunAsync(async () =>
                 {
                     await VsCommon.ShowErrorMessageAsync(
                         "Rust Analyzer",
@@ -153,7 +153,7 @@ public class Options : BaseOptionModel<Options>, ISettingsServiceDefaults
             }
             catch (System.Exception ex)
             {
-                RustAnalyzerPackage.JTF.RunAsync(async () => 
+                RustAnalyzerPackage.JTF.RunAsync(async () =>
                 {
                     await VsCommon.ShowErrorMessageAsync(
                         "Rust Analyzer",
@@ -173,10 +173,10 @@ public class Options : BaseOptionModel<Options>, ISettingsServiceDefaults
         }
         catch (System.Exception ex)
         {
-            RustAnalyzerPackage.JTF.RunAsync(async () => 
+            RustAnalyzerPackage.JTF.RunAsync(async () =>
             {
                 await VsCommon.ShowErrorMessageAsync(
-                    "Rust Analyzer", 
+                    "Rust Analyzer",
                     $"Error merging LSP initialization options: {ex.Message}");
             }).FireAndForget();
             return new JObject();
@@ -187,8 +187,9 @@ public class Options : BaseOptionModel<Options>, ISettingsServiceDefaults
 
     [Browsable(true)]
     [Category(SettingsInfo.KindConfig)]
-    [DisplayName("Rust analyzer environment variables")]
-    [Description("Environment variables passed to rust-analyzer.exe, example:\nRA_LOG=info Env2=Test Env3=Hello")]
+    [DisplayName("Environment variables")]
+    [Description("Environment variables passed to rust-analyzer.exe, example:'''\nRA_LOG=info Env2=Test Env3=Hello\n'''\n" +
+        "Reopening the Solution is required for changes to this setting to take effect.")]
     public string RustAnalyzerEnvArguments { get; set; } = string.Empty;
 
     public JObject GetRustAnalyzerEnvArguments()
@@ -214,7 +215,8 @@ public class Options : BaseOptionModel<Options>, ISettingsServiceDefaults
     [Browsable(true)]
     [Category(SettingsInfo.KindConfig)]
     [DisplayName("Enable Rust Analyzer Stderr Logging")]
-    [Description("If enabled, output from rust-analyzer will be logged to the Output window.")]
+    [Description("If enabled, output from rust-analyzer will be logged to the Output window.\n" +
+        "Reopening the Solution is required for changes to this setting to take effect.")]
     public bool EnableRustAnalyzerStderrLogging { get; set; } = false;
 
 }

--- a/src/RustAnalyzer/Infrastructure/SettingsInfo.cs
+++ b/src/RustAnalyzer/Infrastructure/SettingsInfo.cs
@@ -9,6 +9,7 @@ public class SettingsInfo
     public const string KindDebugger = "Debugger";
     public const string KindBuild = "Build";
     public const string KindTest = "Test";
+    public const string KindConfig = "Rust Analyzer Config";
     public const string TypeCommandLineArguments = nameof(NodeBrowseObject.CommandLineArguments);
     public const string TypeDebuggerEnvironment = nameof(NodeBrowseObject.DebuggerEnvironment);
     public const string TypeDebuggerWorkingDirectory = nameof(NodeBrowseObject.WorkingDirectory);

--- a/src/RustAnalyzer/Infrastructure/VsCommon.cs
+++ b/src/RustAnalyzer/Infrastructure/VsCommon.cs
@@ -58,6 +58,14 @@ public static class VsCommon
         await infoBar.TryShowInfoBarUIAsync();
     }
 
+    public static async Task ShowErrorMessageAsync(string title, string message)
+    {
+        await RustAnalyzerPackage.JTF.SwitchToMainThreadAsync();
+        await CommunityVS.MessageBox.ShowErrorAsync(
+            title.AddPrefixToMessage(),
+            message);
+    }
+
     public static string GetFullName(this VSITEMSELECTION item)
     {
         ThreadHelper.ThrowIfNotOnUIThread();

--- a/src/RustAnalyzer/LanguageService/LanguageClient.cs
+++ b/src/RustAnalyzer/LanguageService/LanguageClient.cs
@@ -50,7 +50,7 @@ public class LanguageClient : ILanguageClient, ILanguageClientCustomMessage2
         }
     }
 
-    public object InitializationOptions => null;
+    public object InitializationOptions { get; set; } = null;
 
     public IEnumerable<string> FilesToWatch => null;
 
@@ -62,6 +62,7 @@ public class LanguageClient : ILanguageClient, ILanguageClientCustomMessage2
 
     public async Task<Connection> ActivateAsync(CancellationToken token)
     {
+        var options = await Options.GetLiveInstanceAsync();
         var rlsPath = await RADownloader.GetExePathAsync();
         L.WriteLine("Starting rust-analyzer from path: {0}.", rlsPath);
         ProcessStartInfo info = new()
@@ -69,19 +70,44 @@ public class LanguageClient : ILanguageClient, ILanguageClientCustomMessage2
             FileName = rlsPath,
             RedirectStandardInput = true,
             RedirectStandardOutput = true,
+            RedirectStandardError = true,
             UseShellExecute = false,
             CreateNoWindow = true,
             WindowStyle = ProcessWindowStyle.Minimized,
             WorkingDirectory = WorkspaceService.CurrentWorkspace?.Location ?? Path.GetDirectoryName(rlsPath),
         };
 
+        foreach (var prop in options.GetRustAnalyzerEnvArguments().Properties())
+        {
+            // Value will never be null, see Options.cs::GetRustAnalyzerEnvArguments implementation
+            info.EnvironmentVariables[prop.Name] = (string)prop.Value!;
+        }
+
         Process process = new()
         {
             StartInfo = info
         };
 
+        string topDir = WorkspaceService.CurrentWorkspace?.Location;
+        var mergedOptions = options.GetMergedLspInitializationOptions(topDir);
+
+        InitializationOptions = mergedOptions;
+        L.WriteLine("Parsing lsp initializationOptions: {0}", InitializationOptions.SerializeObject(Newtonsoft.Json.Formatting.Indented));
+
         if (process.Start())
         {
+            if (options.EnableRustAnalyzerStderrLogging)
+            {
+                _ = Task.Run(async () =>
+                {
+                    string line;
+                    while ((line = await process.StandardError.ReadLineAsync()) != null)
+                    {
+                        L.WriteLine("[rust-analyzer stderr] {0}", line);
+                    }
+                });
+            }
+
             L.WriteLine("Done starting rust-analyzer from path. PID: {0}", process.Id);
             T.TrackEvent("rust-analyzer-start", ("Path", rlsPath));
 


### PR DESCRIPTION
Addressing Issue #48 and #45 

Implements settings-based parsing of configuration for rust-analyzer ([official configuration documentation](https://rust-analyzer.github.io/book/configuration.html)).

### Option to Parse RA Config
Options can be parsed from Settings under "Rust Analyzer > General > Rust Analyzer Config > Rust Analyzer LSP Initialization Options". Additionally, they can be customized per project by placing a JSON file named `lsp_initializationOptions.json` in the project root directory. The two configurations are merged using a deep merge strategy as described [here](https://jsoncompare.com/json-merge-tool). I have chosen this strategy because in many cases it allows for nice extension of global configs for local projects. A shallow merge or just overwriting may, however, be more sensible in some cases where a deep merge means that an object filled in the global setting can't be overwritten by placing an empty object in the local JSON file (`{test: "hi"}` merged with `{}` results in `{test: "hi"}`). The JSON file as settings location seems a bit crude, but it is easy to work with and means that a common configuration for a project may be shared via git, which may be desirable in some cases.
For the setting, I had to use a standard multiline string as VS2022 does not appear to provide a JSON Editor, and implementing one myself seemed excessive. Errors in the provided JSON are handled gracefully, and an error message box is shown to the user.

### Option to Parse RA Process Environment Variables
Adds the option to parse Rust Analyzer environment variables through "Rust Analyzer > General > Rust Analyzer Environment Variables". These may be added as a list of space-separated environment variable arguments. If an argument contains an equals sign, the first equals sign is used to distinguish the name from the value; if no equals sign is present, the value is set to an empty string ("").

### Stderr Logging
I needed to log rust-analyzer stderr output, so I have included a toggle to activate it if needed. It can also be found in the settings.

### Caveats
- I have never worked with C# before. I hope my code quality is sufficient, but realistically I cannot guarantee that I have not included any bad practices.
- I have tested the features, they should handle all common (/possible?) errors fine, but I have not implemented test cases or unit tests for them.
- Some code locations may be awkward, for example, I have placed logic for parsing arguments in the [Options class](https://github.com/kitamstudios/rust-analyzer.vs/blob/master/src/RustAnalyzer/Infrastructure/Options.cs#L32). The general location seems logical, but it might be that the Options class is intended only as an interface and should not contain logic.
- I may have implemented [ShowErrorMessagesAsync](https://github.com/TpvdB/rust-analyzer.vs/blob/06cb3ca5af1c7ece8e293d5658b37f50c9cf878c/src/RustAnalyzer/Infrastructure/VsCommon.cs#L61) in a way that does not fit the pattern used elsewhere.
- Changing the options implemented requires reopening the project to take effect. I have mentioned in the RA Config options description that this is a requirement, but I have not implemented a popup or similar notification to alert the user.

### Additional References
- The main parsing logic is located in [`Options.cs`](https://github.com/kitamstudios/rust-analyzer.vs/blob/master/src/RustAnalyzer/Infrastructure/Options.cs#L32).
- Error handling and message display logic is placed in [`VsCommon.cs`](https://github.com/TpvdB/rust-analyzer.vs/blob/06cb3ca5af1c7ece8e293d5658b37f50c9cf878c/src/RustAnalyzer/Infrastructure/VsCommon.cs#L61).

### Images
- New Settings <img width="1098" height="92" alt="image" src="https://github.com/user-attachments/assets/a53d45ca-43a8-4176-825b-c949505e3d19" />
- Invalid JSON popup 
<img width="482" height="248" alt="image" src="https://github.com/user-attachments/assets/fd66e8a7-f7fa-4e69-aa5f-a5252919ed7e" />

### Solution to #45 and similar:
This issue seems to appear because RA uses different environment variables (or Rust flags(?)) than Cargo, which leads to both invalidating the cached builds of the other (according to [this](https://github.com/LaurentMazare/tch-rs/issues/596) issue). The fix mentioned there is to specify the correct environment variables to RA (I can’t confirm that this works, but the provided changes to the extension now allow for that). Another, easier, although perhaps computationally a bit more wasteful, solution is to simply split up RA and Cargo build directories by providing a config like
```json
{
  "cargo": {
    "targetDir": true
  }
}
```
This makes rust-analyzer use the `<default_build_dir>/rust-analyzer` directory as the target location and doesn’t require further diagnostics or testing to determine which environment variables, Rust flags, or other settings might be wrong.


I will try my best to fix any problems with the code. Thank you for your extensive work on the extension, I really love being able to work with Rust in Visual Studio.
Have a great day!